### PR TITLE
Add treatment for models without tbounds for climo caculation

### DIFF
--- a/arm_diags/basicparameter.py
+++ b/arm_diags/basicparameter.py
@@ -1,9 +1,11 @@
-#test_data_set = 'cmip5cnrmcm5'        # name of the model, which should be included as the /model/test_data_xxxx.nc
+#test_data_set = 'cmip5cnrmcm5'        # Specify name of the test model to find the files
 test_data_set = 'testmodel'
-case_id = 'output_results_newname_full'
+#test_data_set = 'cmip5cesm1cam5'
+#test_data_set = 'cmip5gisse2r'
+case_id = 'output_results_newname'
 
 # Set input path, where the model, observational and cmip data are located.
-base_path = '/Users/zhang40/Documents/ARM_LLNL/repo/arm_diags_data_v2_release_fin_10072020/'
+base_path = '/Users/zhang40/Documents/ARM_LLNL/repo/ARMDiag_v2_data_20201007/'
 
 #test_data_path = base_path+'cmip5'
 test_data_path = base_path+'testmodel'

--- a/arm_diags/diags_all_multisites.json
+++ b/arm_diags/diags_all_multisites.json
@@ -4,70 +4,70 @@
       "diags_set": "set1_tables",
       "sites": ["sgp"],
       "variables": ["tas","pr","clt","hurs","hfss","hfls","rlus","rlds","rsus","rsds","ps","prw","mrsos","od550aer"],
-      "ref_models": ["ACCESS1-0","ACCESS1-3", "CESM1-CAM5","CSIRO-Mk3-6-0", "CanAM4","FGOALS-g2","FGOALS-s2","GFDL-HIRAM-C360","GFDL-HIRAM-C180","GISS-E2-R","inmcm4", "MPI-ESM-LR", "MPI-ESM-MR"],
+      "ref_models": ["ACCESS1-0","ACCESS1-3", "CESM1-CAM5","CSIRO-Mk3-6-0", "CanAM4","FGOALS-g2","FGOALS-s2","GFDL-HIRAM-C360","GFDL-HIRAM-C180","GISS-E2-R","inmcm4", "MPI-ESM-LR", "MPI-ESM-MR", "NorESM1-M"],
       "season": ["ANN","DJF","MAM","JJA","SON"]
                 },
           {
       "diags_set": "set1_tables",
       "sites": ["nsa"],
       "variables": ["tas","clt","hurs","rlus","rlds","rsus","rsds","ps","prw"],
-      "ref_models": ["ACCESS1-0","ACCESS1-3", "CESM1-CAM5","CSIRO-Mk3-6-0", "CanAM4","FGOALS-g2","FGOALS-s2","GFDL-HIRAM-C360","GFDL-HIRAM-C180","GISS-E2-R","inmcm4", "MPI-ESM-LR", "MPI-ESM-MR"],
+      "ref_models": ["ACCESS1-0","ACCESS1-3", "CESM1-CAM5","CSIRO-Mk3-6-0", "CanAM4","FGOALS-g2","FGOALS-s2","GFDL-HIRAM-C360","GFDL-HIRAM-C180","GISS-E2-R","inmcm4", "MPI-ESM-LR", "MPI-ESM-MR", "NorESM1-M"],
       "season": ["ANN","DJF","MAM","JJA","SON"]
                 },
           {
       "diags_set": "set1_tables",
       "sites": ["twpc1"],
       "variables": ["tas","pr","clt","hurs","rlus","rlds","rsus","rsds","ps","prw"],
-      "ref_models": ["ACCESS1-0","ACCESS1-3", "CESM1-CAM5","CSIRO-Mk3-6-0", "CanAM4","FGOALS-g2","FGOALS-s2","GFDL-HIRAM-C360","GFDL-HIRAM-C180","GISS-E2-R","inmcm4", "MPI-ESM-LR", "MPI-ESM-MR"],
+      "ref_models": ["ACCESS1-0","ACCESS1-3", "CESM1-CAM5","CSIRO-Mk3-6-0", "CanAM4","FGOALS-g2","FGOALS-s2","GFDL-HIRAM-C360","GFDL-HIRAM-C180","GISS-E2-R","inmcm4", "MPI-ESM-LR", "MPI-ESM-MR", "NorESM1-M"],
       "season": ["ANN","DJF","MAM","JJA","SON"]
                 },
           {
       "diags_set": "set1_tables",
       "sites": ["twpc2"],
       "variables": ["tas","pr","clt","hurs","rlus","rlds","rsus","rsds","ps","prw"],
-      "ref_models": ["ACCESS1-0","ACCESS1-3", "CESM1-CAM5","CSIRO-Mk3-6-0", "CanAM4","FGOALS-g2","FGOALS-s2","GFDL-HIRAM-C360","GFDL-HIRAM-C180","GISS-E2-R","inmcm4", "MPI-ESM-LR", "MPI-ESM-MR"],
+      "ref_models": ["ACCESS1-0","ACCESS1-3", "CESM1-CAM5","CSIRO-Mk3-6-0", "CanAM4","FGOALS-g2","FGOALS-s2","GFDL-HIRAM-C360","GFDL-HIRAM-C180","GISS-E2-R","inmcm4", "MPI-ESM-LR", "MPI-ESM-MR", "NorESM1-M"],
       "season": ["ANN","DJF","MAM","JJA","SON"]
                 },
           {
       "diags_set": "set1_tables",
       "sites": ["twpc3"],
       "variables": ["tas","pr","clt","hurs","rlus","rlds","rsus","rsds","ps","prw"],
-      "ref_models": ["ACCESS1-0","ACCESS1-3", "CESM1-CAM5","CSIRO-Mk3-6-0", "CanAM4","FGOALS-g2","FGOALS-s2","GFDL-HIRAM-C360","GFDL-HIRAM-C180","GISS-E2-R","inmcm4", "MPI-ESM-LR", "MPI-ESM-MR"],
+      "ref_models": ["ACCESS1-0","ACCESS1-3", "CESM1-CAM5","CSIRO-Mk3-6-0", "CanAM4","FGOALS-g2","FGOALS-s2","GFDL-HIRAM-C360","GFDL-HIRAM-C180","GISS-E2-R","inmcm4", "MPI-ESM-LR", "MPI-ESM-MR", "NorESM1-M"],
       "season": ["ANN","DJF","MAM","JJA","SON"]
                 },
           {
       "diags_set": "set2_annual_cycle",
       "sites": ["sgp"],
       "variables": ["tas","pr","clt","hurs","hfss","hfls","rlus","rlds","rsus","rsds","ps","prw","mrsos","od550aer"],
-      "ref_models": ["ACCESS1-0","ACCESS1-3", "CESM1-CAM5","CSIRO-Mk3-6-0", "CanAM4","FGOALS-g2","FGOALS-s2","GFDL-HIRAM-C360","GFDL-HIRAM-C180","GISS-E2-R","inmcm4", "MPI-ESM-LR", "MPI-ESM-MR"],
+      "ref_models": ["ACCESS1-0","ACCESS1-3", "CESM1-CAM5","CSIRO-Mk3-6-0", "CanAM4","FGOALS-g2","FGOALS-s2","GFDL-HIRAM-C360","GFDL-HIRAM-C180","GISS-E2-R","inmcm4", "MPI-ESM-LR", "MPI-ESM-MR", "NorESM1-M"],
       "season": ["J","F","M","A","M","J","J","A","S","O","N","D"]
                 },
           {
       "diags_set": "set2_annual_cycle",
       "sites": ["nsa"],
       "variables": ["tas","clt","hurs","rlus","rlds","rsus","rsds","ps","prw"],
-      "ref_models": ["ACCESS1-0","ACCESS1-3", "CESM1-CAM5","CSIRO-Mk3-6-0", "CanAM4","FGOALS-g2","FGOALS-s2","GFDL-HIRAM-C360","GFDL-HIRAM-C180","GISS-E2-R","inmcm4", "MPI-ESM-LR", "MPI-ESM-MR"],
+      "ref_models": ["ACCESS1-0","ACCESS1-3", "CESM1-CAM5","CSIRO-Mk3-6-0", "CanAM4","FGOALS-g2","FGOALS-s2","GFDL-HIRAM-C360","GFDL-HIRAM-C180","GISS-E2-R","inmcm4", "MPI-ESM-LR", "MPI-ESM-MR", "NorESM1-M"],
       "season": ["J","F","M","A","M","J","J","A","S","O","N","D"]
                 },
           {
       "diags_set": "set2_annual_cycle",
       "sites": ["twpc1"],
       "variables": ["tas","pr","clt","hurs","rlus","rlds","rsus","rsds","ps","prw"],
-      "ref_models": ["ACCESS1-0","ACCESS1-3", "CESM1-CAM5","CSIRO-Mk3-6-0", "CanAM4","FGOALS-g2","FGOALS-s2","GFDL-HIRAM-C360","GFDL-HIRAM-C180","GISS-E2-R","inmcm4", "MPI-ESM-LR", "MPI-ESM-MR"],
+      "ref_models": ["ACCESS1-0","ACCESS1-3", "CESM1-CAM5","CSIRO-Mk3-6-0", "CanAM4","FGOALS-g2","FGOALS-s2","GFDL-HIRAM-C360","GFDL-HIRAM-C180","GISS-E2-R","inmcm4", "MPI-ESM-LR", "MPI-ESM-MR", "NorESM1-M"],
       "season": ["J","F","M","A","M","J","J","A","S","O","N","D"]
                 },
           {
       "diags_set": "set2_annual_cycle",
       "sites": ["twpc2"],
       "variables": ["tas","pr","clt","hurs","rlus","rlds","rsus","rsds","ps","prw"],
-      "ref_models": ["ACCESS1-0","ACCESS1-3", "CESM1-CAM5","CSIRO-Mk3-6-0", "CanAM4","FGOALS-g2","FGOALS-s2","GFDL-HIRAM-C360","GFDL-HIRAM-C180","GISS-E2-R","inmcm4", "MPI-ESM-LR", "MPI-ESM-MR"],
+      "ref_models": ["ACCESS1-0","ACCESS1-3", "CESM1-CAM5","CSIRO-Mk3-6-0", "CanAM4","FGOALS-g2","FGOALS-s2","GFDL-HIRAM-C360","GFDL-HIRAM-C180","GISS-E2-R","inmcm4", "MPI-ESM-LR", "MPI-ESM-MR", "NorESM1-M"],
       "season": ["J","F","M","A","M","J","J","A","S","O","N","D"]
                 },
           {
       "diags_set": "set2_annual_cycle",
       "sites": ["twpc3"],
       "variables": ["tas","pr","clt","hurs","rlus","rlds","rsus","rsds","ps","prw"],
-      "ref_models": ["ACCESS1-0","ACCESS1-3", "CESM1-CAM5","CSIRO-Mk3-6-0", "CanAM4","FGOALS-g2","FGOALS-s2","GFDL-HIRAM-C360","GFDL-HIRAM-C180","GISS-E2-R","inmcm4", "MPI-ESM-LR", "MPI-ESM-MR"],
+      "ref_models": ["ACCESS1-0","ACCESS1-3", "CESM1-CAM5","CSIRO-Mk3-6-0", "CanAM4","FGOALS-g2","FGOALS-s2","GFDL-HIRAM-C360","GFDL-HIRAM-C180","GISS-E2-R","inmcm4", "MPI-ESM-LR", "MPI-ESM-MR", "NorESM1-M"],
       "season": ["J","F","M","A","M","J","J","A","S","O","N","D"]
                 },
           {

--- a/arm_diags/src/seasonal_mean.py
+++ b/arm_diags/src/seasonal_mean.py
@@ -62,7 +62,7 @@ def seasonal_mean_table(parameter):
 
     for j, variable in enumerate(variables): 
         try:
-            var = fin (variable)
+            var = fin(variable)
             #test_var_season[j, :] = var_seasons(var, seasons)
             test_var_season[j, :] = climo(var, seasons)
 

--- a/arm_diags/src/utils.py
+++ b/arm_diags/src/utils.py
@@ -1,6 +1,7 @@
 import numpy as np
 import numpy.ma as ma
 import cdms2
+import cdutil
 
 
 def climo(var, season):
@@ -35,6 +36,10 @@ def climo(var, season):
         return var
 
     tbounds = var_time.getBounds()
+    if tbounds is None:
+        cdutil.setTimeBoundsMonthly(var)
+        tbounds = var.getTime().getBounds()
+        
     var_time[:] = 0.5*(tbounds[:,0]+tbounds[:,1])
     var_time_absolute = var_time.asComponentTime()
 


### PR DESCRIPTION
Some cmip model don't have time bounds, which are required for climatology calculation. This PR adds treatment to set monthly time bounds for this corner case and brings in more models for inter-comparison.